### PR TITLE
Fix .env parsing error and finalize Docker setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
-DJANGO_SETTINGS_MODULE='config.django.local
-SECRET_KEY='django-insecure-3#kl1t_v$f16r$)6&wt@3#+bqbf&c6qrdnt^$wv8-qvt1r@i$%'
+DJANGO_SETTINGS_MODULE='config.django.local'
+SECRET_KEY="django-insecure-3#kl1t_v$f16r$)6&wt@3#+bqbf&c6qrdnt^$wv8-qvt1r@i$%"
 DJANGO_BUG=True
 ALLOWED_HOSTS=['*']
 CELERY_BROKER='redis://redis.6379/0'


### PR DESCRIPTION
This commit fixes a parsing error in the .env file that was preventing Docker services from starting. The `SECRET_KEY` value contained special characters and was not correctly quoted, and another variable was missing a closing quote.

This commit applies the following fixes:
1. Adds a missing closing quote to `DJANGO_SETTINGS_MODULE` in `.env`.
2. Encloses the `SECRET_KEY` value in double quotes in `.env` to handle special characters safely.

This change is the final step in the Docker setup refactoring, which also included moving `Dockerfile` and `docker-compose.yml` to the project root and correcting their internal paths. The application should now build and run reliably.