### PR TITLE
feat: Add Flower to production environment

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -20,3 +20,8 @@ CREATE_SUPERUSER=0
 DJANGO_SUPERUSER_EMAIL=
 DJANGO_SUPERUSER_FULL_NAME=
 DJANGO_SUPERUSER_PASSWORD=
+
+# Flower
+# ------------------------------------------------------------------------------
+FLOWER_USER=admin
+FLOWER_PASSWORD=changeme

--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ Create a `.env.prod` file in the root of the project and add your production-spe
 - `DATABASE_URL`: The URL of your production PostgreSQL database.
 - `CELERY_BROKER_URL`: The URL of your production Redis instance.
 - `CELERY_RESULT_BACKEND`: The URL of your production Redis instance.
+- `FLOWER_USER`: The username for the Flower dashboard.
+- `FLOWER_PASSWORD`: The password for the Flower dashboard.
 
 ### Running in Production
 To build and run the application in production mode, use the `docker-compose.prod.yml` file:
@@ -287,12 +289,12 @@ This project is configured for deployment on [Render](https://render.com/) using
 
 3.  **Set Environment Variables:**
     *   Render will automatically provision a PostgreSQL database and a Redis instance and inject their connection URLs into your services.
-    *   You will need to add a `SECRET_KEY` to your environment. You can do this by creating an "Environment Group" in Render and adding your `SECRET_KEY` there. Then, link this environment group to your `taskverse-web`, `taskverse-worker`, and `taskverse-beat` services. Alternatively, you can set the `SECRET_KEY` environment variable manually for each service in the Render dashboard.
+    *   You will need to add secrets like `SECRET_KEY`, `FLOWER_USER`, and `FLOWER_PASSWORD` to your environment. The recommended way to do this is by creating an **Environment Group** in Render and adding your secrets there. You can then link this group to all your services (`taskverse-web`, `taskverse-worker`, `taskverse-beat`, and `taskverse-flower`).
 
 4.  **Deploy:**
-    *   Click "Create" to deploy your services. Render will build the Docker image, run migrations (as defined by the `preDeployCommand`), and start your web, worker, and beat services.
+    *   Click "Create" to deploy your services. Render will build the Docker image, run migrations (as defined by the `preDeployCommand`), and start your web, worker, beat, and flower services.
 
-Your application will be live at the URL provided by Render for the `taskverse-web` service.
+Your application will be live at the URL provided by Render for the `taskverse-web` service. The Flower dashboard will be available at the URL for the `taskverse-flower` service.
 
 ## Production notes
 - Use `taskverse.django.production` and set `DJANGO_SETTINGS_MODULE` accordingly.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres:15
@@ -62,5 +60,21 @@ services:
         condition: service_healthy
     command: celery -A taskverse beat --loglevel=info
 
+  flower:
+    build:
+      context: .
+      dockerfile: Dockerfile.prod
+    ports:
+      - "5555:5555"
+    env_file:
+      - ./.env.prod
+    volumes:
+      - flower_data:/data
+    depends_on:
+      redis:
+        condition: service_healthy
+    command: celery -A taskverse flower --basic_auth=${FLOWER_USER}:${FLOWER_PASSWORD} --persistent=True --db=/data/flower.db
+
 volumes:
   postgres_data:
+  flower_data:

--- a/render.yaml
+++ b/render.yaml
@@ -117,6 +117,47 @@ services:
           name: taskverse-web
           envVar: ALLOWED_HOSTS
 
+  - type: web
+    name: taskverse-flower
+    env: docker
+    dockerfilePath: ./Dockerfile.prod
+    dockerContext: .
+    plan: starter
+    healthCheckPath: /login
+    envVars:
+      - key: DATABASE_URL
+        fromService:
+          type: pserv
+          name: taskverse-postgres
+          property: connectionString
+      - key: CELERY_BROKER_URL
+        fromService:
+          type: pserv
+          name: taskverse-redis
+          property: connectionString
+      - key: CELERY_RESULT_BACKEND
+        fromService:
+          type: pserv
+          name: taskverse-redis
+          property: connectionString
+      - key: DJANGO_SETTINGS_MODULE
+        value: taskverse.django.production
+      - key: SECRET_KEY
+        fromService:
+          type: web
+          name: taskverse-web
+          envVar: SECRET_KEY
+      - key: ALLOWED_HOSTS
+        fromService:
+          type: web
+          name: taskverse-web
+          envVar: ALLOWED_HOSTS
+      - key: FLOWER_USER
+        generateValue: true
+      - key: FLOWER_PASSWORD
+        generateValue: true
+    command: celery -A taskverse flower --basic_auth=${FLOWER_USER}:${FLOWER_PASSWORD}
+
 databases:
   - name: taskverse-db
     plan: free


### PR DESCRIPTION
This commit adds the Flower service to the production environment for monitoring Celery tasks.

It includes:
- The Flower service added to `docker-compose.prod.yml` with basic authentication and persistent storage.
- The Flower service added to `render.yaml` as a web service with basic authentication.
- Updated `.env.prod.example` with `FLOWER_USER` and `FLOWER_PASSWORD` variables.
- Updated `README.md` to document the Flower service and its configuration for both Docker Compose and Render deployments.
- Removed the obsolete `version` tag from `docker-compose.prod.yml`.