### PR TITLE
feat: Finalize Production and Render Deployment Configuration

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,10 +3,8 @@ services:
     image: postgres:15
     volumes:
       - postgres_data:/var/lib/postgresql/data
-    environment:
-      POSTGRES_DB: taskverse_db
-      POSTGRES_USER: daniel
-      POSTGRES_PASSWORD: '@daniel09033'
+    env_file:
+      - ./.env.prod
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U daniel -d taskverse_db"]
       interval: 10s
@@ -27,13 +25,8 @@ services:
       dockerfile: Dockerfile.prod
     ports:
       - "8000:8000"
-    environment:
-      DJANGO_SETTINGS_MODULE: taskverse.django.production
-      SECRET_KEY: "this-is-a-temporary-insecure-key-for-debugging"
-      ALLOWED_HOSTS: "localhost,127.0.0.1"
-      DATABASE_URL: "postgres://daniel:@daniel09033@postgres:5432/taskverse_db"
-      CELERY_BROKER_URL: "redis://redis:6379/0"
-      CELERY_RESULT_BACKEND: "redis://redis:6379/0"
+    env_file:
+      - ./.env.prod
     depends_on:
       postgres:
         condition: service_healthy
@@ -45,12 +38,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.prod
-    environment:
-      DJANGO_SETTINGS_MODULE: taskverse.django.production
-      SECRET_KEY: "this-is-a-temporary-insecure-key-for-debugging"
-      DATABASE_URL: "postgres://daniel:@daniel09033@postgres:5432/taskverse_db"
-      CELERY_BROKER_URL: "redis://redis:6379/0"
-      CELERY_RESULT_BACKEND: "redis://redis:6379/0"
+    env_file:
+      - ./.env.prod
     depends_on:
       postgres:
         condition: service_healthy
@@ -62,12 +51,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.prod
-    environment:
-      DJANGO_SETTINGS_MODULE: taskverse.django.production
-      SECRET_KEY: "this-is-a-temporary-insecure-key-for-debugging"
-      DATABASE_URL: "postgres://daniel:@daniel09033@postgres:5432/taskverse_db"
-      CELERY_BROKER_URL: "redis://redis:6379/0"
-      CELERY_RESULT_BACKEND: "redis://redis:6379/0"
+    env_file:
+      - ./.env.prod
     depends_on:
       postgres:
         condition: service_healthy
@@ -81,20 +66,14 @@ services:
       dockerfile: Dockerfile.prod
     ports:
       - "5555:5555"
-    environment:
-      DJANGO_SETTINGS_MODULE: taskverse.django.production
-      SECRET_KEY: "this-is-a-temporary-insecure-key-for-debugging"
-      DATABASE_URL: "postgres://daniel:@daniel09033@postgres:5432/taskverse_db"
-      CELERY_BROKER_URL: "redis://redis:6379/0"
-      CELERY_RESULT_BACKEND: "redis://redis:6379/0"
-      FLOWER_USER: "admin"
-      FLOWER_PASSWORD: "changeme"
+    env_file:
+      - ./.env.prod
     volumes:
       - flower_data:/data
     depends_on:
       redis:
         condition: service_healthy
-    command: celery -A taskverse flower --basic_auth=$${FLOWER_USER}:$${FLOWER_PASSWORD} --persistent=True --db=/data/flower.db
+    command: celery -A taskverse flower --basic_auth=${FLOWER_USER}:${FLOWER_PASSWORD} --persistent=True --db=/data/flower.db
 
 volumes:
   postgres_data:

--- a/taskverse/settings/entrypoint.sh
+++ b/taskverse/settings/entrypoint.sh
@@ -47,16 +47,6 @@ PYEOF
 fi
 
 if [ "${SKIP_DJANGO_BOOTSTRAP:-0}" != "1" ]; then
-  # --- DEBUGGING PERMISSIONS ---
-  echo "--- DEBUGGING PERMISSIONS ---"
-  echo "Current user: $(whoami)"
-  echo "Listing permissions for /home/app:"
-  ls -ld /home/app
-  echo "Listing permissions for /home/app/web:"
-  ls -ld /home/app/web
-  echo "--- END DEBUGGING ---"
-  # --- END DEBUGGING ---
-
   # Collect static files
   python manage.py collectstatic --noinput || true
 fi


### PR DESCRIPTION
This commit provides a complete, working configuration for deploying the application to both a local Docker environment and the Render cloud platform.

This work includes:
- Initial setup of a production-ready `Dockerfile.prod` using a non-root user and multi-stage builds.
- A `docker-compose.prod.yml` for running the entire stack (web, worker, beat, flower) in a production-like local environment.
- A comprehensive `render.yaml` file for automated "Infrastructure as Code" deployment on Render.
- Addition of the Flower monitoring service to all production configurations, protected by Basic Authentication.
- A fix for a file permission error related to the `collectstatic` command during container startup.
- All temporary debugging code has been removed.

The project is now confirmed to be in a deployable state.