### PR TITLE
fix: Use production settings for Render migrations

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -6,7 +6,7 @@ services:
     dockerContext: .
     plan: starter
     healthCheckPath: /
-    preDeployCommand: "python manage.py migrate"
+    preDeployCommand: "python manage.py migrate --settings=taskverse.django.production"
     envVars:
       - key: DATABASE_URL
         fromService:


### PR DESCRIPTION
This commit fixes a deployment error on Render where the database migration command was failing.

The error `could not translate host name "postgres"` occurred because the `migrate` command was using default development settings instead of the production settings.

This change modifies the `render.yaml` to explicitly specify `--settings=taskverse.django.production` for the `preDeployCommand`, ensuring the correct database URL is used during deployment.