### PR TITLE
fix: Default to production settings for deployment

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -6,7 +6,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'taskverse.django.local')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'taskverse.django.production')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/taskverse/wsgi.py
+++ b/taskverse/wsgi.py
@@ -10,6 +10,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'taskverse.django.local')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'taskverse.django.production')
 
 application = get_wsgi_application()


### PR DESCRIPTION
This commit provides a definitive fix for the Render deployment errors by making the production settings the default for the application.

The previous `OperationalError` on Render was caused by the application defaulting to `local` settings in some execution paths (`manage.py`, `wsgi.py`), which caused it to ignore the `DATABASE_URL` provided by Render.

This change modifies `manage.py` and `wsgi.py` to default to `taskverse.django.production`. This ensures the application is always "production-first", making deployments more robust and reliable. Local development will now require explicitly setting `DJANGO_SETTINGS_MODULE=taskverse.django.local` in a local `.env` file, which is a safer pattern.

This should be the final change required for a successful deployment.